### PR TITLE
Refactor

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -35,6 +35,10 @@
       dialog.show();
     });
 
+    dialog.addEventListener('show', () => {
+      output.innerHTML = '<p>The dialog was shown.</p>';
+    });
+
     dialog.addEventListener('close', () => {
       output.innerHTML = '<p>The dialog was closed.</p>';
     });

--- a/demo/index.html
+++ b/demo/index.html
@@ -20,6 +20,7 @@
         </p>
         <button data-a11y-dialog-close>Close</button>
         <button data-a11y-dialog-cancel>Cancel</button>
+        <button data-escape-dialog>Escape from dialog</button>
       </div>
     </a11y-dialog>
     <div id="output"><p>Close the dialog to change this message</p></div>
@@ -28,6 +29,7 @@
     const dialog = document.querySelector('a11y-dialog');
     const output = document.querySelector('#output');
     const showBtn = document.querySelector('[data-a11y-dialog-show]');
+    const escapeBtn = document.querySelector('[data-escape-dialog]')
 
     showBtn.addEventListener('click', () => {
       dialog.show();
@@ -40,5 +42,9 @@
     dialog.addEventListener('cancel', () => {
       output.innerHTML = '<p>The dialog was canceled.</p>';
     });
+
+    escapeBtn.addEventListener('click', () => {
+      showBtn.focus()
+    })
   </script>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -23,32 +23,45 @@
         <button data-escape-dialog>Escape from dialog</button>
       </div>
     </a11y-dialog>
-    <div id="output"><p>Close the dialog to change this message</p></div>
+    <div id="output">
+      <p>Interact with the dialog to change this message</p>
+    </div>
   </body>
   <script>
     const dialog = document.querySelector('a11y-dialog');
     const output = document.querySelector('#output');
     const showBtn = document.querySelector('[data-a11y-dialog-show]');
-    const escapeBtn = document.querySelector('[data-escape-dialog]')
+
+    const VERB_BY_DIALOG_EVT = {
+      show: 'shown',
+      cancel: 'canceled',
+      close: 'closed',
+    };
+
+    const dialogEvents = ['cancel', 'close', 'show'];
 
     showBtn.addEventListener('click', () => {
       dialog.show();
     });
 
-    dialog.addEventListener('show', () => {
-      output.innerHTML = '<p>The dialog was shown.</p>';
+    dialogEvents.forEach(evtName => {
+      document.addEventListener(
+        evtName,
+        () => {
+          output.innerHTML = `<p>The dialog was ${VERB_BY_DIALOG_EVT[evtName]}.</p>`;
+        },
+        true
+      );
     });
 
-    dialog.addEventListener('close', () => {
-      output.innerHTML = '<p>The dialog was closed.</p>';
-    });
-
-    dialog.addEventListener('cancel', () => {
-      output.innerHTML = '<p>The dialog was canceled.</p>';
-    });
-
-    escapeBtn.addEventListener('click', () => {
-      showBtn.focus()
-    })
+    document.addEventListener(
+      'click',
+      function (evt) {
+        if (evt.target.matches('[data-escape-dialog]')) {
+          showBtn.focus();
+        }
+      },
+      true
+    );
   </script>
 </html>

--- a/demo/styles.css
+++ b/demo/styles.css
@@ -19,6 +19,10 @@ button {
   line-height: inherit;
 }
 
+a11y-dialog:not(:defined) {
+  display: none;
+}
+
 a11y-dialog:not([open]) {
   visibility: hidden;
   opacity: 0;

--- a/src/A11yDialog.ts
+++ b/src/A11yDialog.ts
@@ -62,13 +62,13 @@ export class A11yDialog extends HTMLElement {
     this.removeEventListener('click', this.__handleCloseDelegates, true);
   }
 
-  show = () => {
+  show() {
     this.open = true;
 
     this.dispatchEvent(new Event('show'));
   };
 
-  close = (type: 'close' | 'cancel' = 'close') => {
+  close(type: 'close' | 'cancel' = 'close') {
     this.open = false;
 
     this.dispatchEvent(new Event(type));
@@ -76,7 +76,7 @@ export class A11yDialog extends HTMLElement {
 
   protected __cancel = this.close.bind(this, 'cancel');
 
-  protected __handleCloseDelegates: EventListener = evt => {
+  protected __handleCloseDelegates(evt: Event) {
     const target = evt.target as HTMLElement;
 
     if (target.matches('[data-a11y-dialog-close]')) {
@@ -92,7 +92,7 @@ export class A11yDialog extends HTMLElement {
    * Private event handler used when listening to some specific key presses
    * (namely ESC and TAB)
    */
-  protected bindKeypress = (event: KeyboardEvent) => {
+  protected bindKeypress(event: KeyboardEvent) {
     // If the dialog is shown and the ESC key is pressed,
     // cancel the dialog
     if (event.key === 'Escape') {
@@ -107,7 +107,7 @@ export class A11yDialog extends HTMLElement {
     }
   };
 
-  protected maintainFocus = (event: FocusEvent) => {
+  protected maintainFocus(event: FocusEvent) {
     if (
       !(event.target as HTMLElement).closest(
         '[aria-modal="true"], [data-a11y-dialog-ignore-focus-trap]'

--- a/src/A11yDialog.ts
+++ b/src/A11yDialog.ts
@@ -52,9 +52,9 @@ function bindKeypress(this: Instance, event: KeyboardEvent) {
 
 function maintainFocus(this: Instance, event: FocusEvent) {
   const dialog = this;
-  const target = event.relatedTarget as HTMLElement;
+  const target = event.relatedTarget as HTMLElement | undefined;
 
-  if (!target.closest(`#${dialog.id}`)) {
+  if (!target?.closest(`#${dialog.id}`)) {
     moveFocusToDialog(dialog);
   }
 }

--- a/src/A11yDialog.ts
+++ b/src/A11yDialog.ts
@@ -26,7 +26,7 @@ function bindDelegatedClicks(
   }
 
   if (target.matches('[data-a11y-dialog-cancel]')) {
-    cancel.call(dialog)
+    fireEvent.call(dialog, 'cancel')
   }
 }
 
@@ -40,7 +40,7 @@ function bindKeypress(this: Instance, event: KeyboardEvent) {
   // cancel the dialog
   if (event.key === 'Escape') {
     event.preventDefault();
-    cancel.call(dialog)
+    fireEvent.call(dialog, 'cancel')
   }
 
   // If the dialog is shown and the TAB key is pressed, make sure the focus
@@ -59,13 +59,11 @@ function maintainFocus(this: Instance, event: FocusEvent) {
   }
 }
 
-function cancel(this: Instance) {
-  this.open = false;
+function fireEvent(this: Instance, evtName: A11yDialogEvent) {
+  this.open = evtName === 'show'
 
-  this.dispatchEvent(new Event('cancel'));
+  this.dispatchEvent(new Event(evtName))
 }
-
-export type A11yDialogEvent = 'cancel' | 'close' | 'show';
 export class A11yDialog extends HTMLElement {
   protected previouslyFocused: null | HTMLElement;
 
@@ -106,7 +104,7 @@ export class A11yDialog extends HTMLElement {
 
     this.shadowRoot
       ?.querySelector('[part="overlay"]')
-      ?.addEventListener('click', cancel.bind(this));
+      ?.addEventListener('click', fireEvent.bind(this, 'cancel'));
 
     this.addEventListener('click', bindDelegatedClicks, true);
   }
@@ -115,17 +113,9 @@ export class A11yDialog extends HTMLElement {
     this.removeEventListener('click', bindDelegatedClicks, true);
   }
 
-  show() {
-    this.open = true;
+  show = fireEvent.bind(this, 'show')
 
-    this.dispatchEvent(new Event('show'));
-  }
-
-  close() {
-    this.open = false;
-
-    this.dispatchEvent(new Event('close'));
-  }
+  close = fireEvent.bind(this, 'close')
 
   attributeChangedCallback(
     name: string,
@@ -161,3 +151,6 @@ export class A11yDialog extends HTMLElement {
     }
   }
 }
+
+export type A11yDialogElement = Instance
+export type A11yDialogEvent = 'cancel' | 'close' | 'show';

--- a/src/A11yDialog.ts
+++ b/src/A11yDialog.ts
@@ -40,7 +40,7 @@ function bindKeypress(this: Instance, event: KeyboardEvent) {
   // cancel the dialog
   if (event.key === 'Escape') {
     event.preventDefault();
-    fireEvent.call(dialog, 'cancel')
+    fireEvent.call(dialog, 'cancel');
   }
 
   // If the dialog is shown and the TAB key is pressed, make sure the focus
@@ -52,17 +52,17 @@ function bindKeypress(this: Instance, event: KeyboardEvent) {
 
 function maintainFocus(this: Instance, event: FocusEvent) {
   const dialog = this;
-  const target = event.relatedTarget as HTMLElement | undefined;
+  const nextActiveEl = event.relatedTarget as HTMLElement | null;
 
-  if (!target?.closest(`#${dialog.id}`)) {
+  if (!nextActiveEl?.closest('a11y-dialog')) {
     moveFocusToDialog(dialog);
   }
 }
 
 function fireEvent(this: Instance, evtName: A11yDialogEvent) {
-  this.open = evtName === 'show'
+  this.open = evtName === 'show';
 
-  this.dispatchEvent(new Event(evtName))
+  this.dispatchEvent(new Event(evtName));
 }
 export class A11yDialog extends HTMLElement {
   protected previouslyFocused: null | HTMLElement;
@@ -107,15 +107,19 @@ export class A11yDialog extends HTMLElement {
       ?.addEventListener('click', fireEvent.bind(this, 'cancel'));
 
     this.addEventListener('click', bindDelegatedClicks, true);
+    this.addEventListener('keydown', bindKeypress as EventListener, true);
+    this.addEventListener('focusout', maintainFocus as EventListener, true);
   }
 
   disconnectedCallback() {
     this.removeEventListener('click', bindDelegatedClicks, true);
+    this.removeEventListener('keydown', bindKeypress as EventListener, true);
+    this.removeEventListener('focusout', maintainFocus as EventListener, true);
   }
 
-  show = fireEvent.bind(this, 'show')
+  show = fireEvent.bind(this, 'show');
 
-  close = fireEvent.bind(this, 'close')
+  close = fireEvent.bind(this, 'close');
 
   attributeChangedCallback(
     name: string,
@@ -129,28 +133,14 @@ export class A11yDialog extends HTMLElement {
         this.previouslyFocused = document.activeElement as HTMLElement;
 
         moveFocusToDialog(this);
-
-        this.addEventListener('keydown', bindKeypress as EventListener, true);
-        this.addEventListener('focusout', maintainFocus as EventListener, true);
       } else {
         this.open = false;
 
         this.previouslyFocused?.focus();
-
-        this.removeEventListener(
-          'keydown',
-          bindKeypress as EventListener,
-          true
-        );
-        this.removeEventListener(
-          'focusout',
-          maintainFocus as EventListener,
-          true
-        );
       }
     }
   }
 }
 
-export type A11yDialogElement = Instance
+export type A11yDialogElement = Instance;
 export type A11yDialogEvent = 'cancel' | 'close' | 'show';

--- a/src/A11yDialog.ts
+++ b/src/A11yDialog.ts
@@ -4,17 +4,15 @@
 
 import { moveFocusToDialog, trapTabKey } from './utils';
 
-export type A11yDialogEvent = 'cancel' | 'close' | 'show';
-
-const tmp = document.createElement('template');
-tmp.innerHTML = `
+const template = document.createElement('template');
+template.innerHTML = `
   <div part="overlay" part="overlay"></div>
   <div part="content" role="document">
     <slot name="content"></slot>
   </div>
 `;
 
-function handleCloseDelegates(
+function bindDelegatedClicks(
   this: InstanceType<typeof A11yDialog>,
   evt: Event
 ) {
@@ -29,6 +27,7 @@ function handleCloseDelegates(
   }
 }
 
+export type A11yDialogEvent = 'cancel' | 'close' | 'show';
 export class A11yDialog extends HTMLElement {
   protected previouslyFocused: null | HTMLElement;
 
@@ -54,7 +53,7 @@ export class A11yDialog extends HTMLElement {
     super();
     // Create a shadow root
     this.attachShadow({ mode: 'open' }).appendChild(
-      tmp.content.cloneNode(true)
+      template.content.cloneNode(true)
     );
 
     this.previouslyFocused = null;
@@ -71,11 +70,11 @@ export class A11yDialog extends HTMLElement {
       ?.querySelector('[part="overlay"]')
       ?.addEventListener('click', this.__cancel);
 
-    this.addEventListener('click', handleCloseDelegates, true);
+    this.addEventListener('click', bindDelegatedClicks, true);
   }
 
   disconnectedCallback() {
-    this.removeEventListener('click', handleCloseDelegates, true);
+    this.removeEventListener('click', bindDelegatedClicks, true);
   }
 
   show() {

--- a/src/A11yDialog.ts
+++ b/src/A11yDialog.ts
@@ -8,7 +8,7 @@ export type A11yDialogEvent = 'cancel' | 'close' | 'show';
 
 const tmp = document.createElement('template');
 tmp.innerHTML = `
-  <div part="overlay" part="overlay"><div>
+  <div part="overlay" part="overlay"></div>
   <div part="content" role="document">
     <slot name="content"></slot>
   </div>

--- a/src/A11yDialog.ts
+++ b/src/A11yDialog.ts
@@ -1,5 +1,6 @@
-/* eslint-disable lit-a11y/click-events-have-key-events */
 /* eslint-disable lines-between-class-members */
+/* eslint-disable no-use-before-define */
+/* eslint-disable lit-a11y/click-events-have-key-events */
 
 import { moveFocusToDialog, trapTabKey } from './utils';
 
@@ -12,6 +13,21 @@ tmp.innerHTML = `
     <slot name="content"></slot>
   </div>
 `;
+
+function handleCloseDelegates(
+  this: InstanceType<typeof A11yDialog>,
+  evt: Event
+) {
+  const target = evt.target as HTMLElement;
+
+  if (target.matches('[data-a11y-dialog-close]')) {
+    this.close();
+  }
+
+  if (target.matches('[data-a11y-dialog-cancel]')) {
+    this.__cancel();
+  }
+}
 
 export class A11yDialog extends HTMLElement {
   protected previouslyFocused: null | HTMLElement;
@@ -55,38 +71,27 @@ export class A11yDialog extends HTMLElement {
       ?.querySelector('[part="overlay"]')
       ?.addEventListener('click', this.__cancel);
 
-    this.addEventListener('click', this.__handleCloseDelegates, true);
+    this.addEventListener('click', handleCloseDelegates, true);
   }
 
   disconnectedCallback() {
-    this.removeEventListener('click', this.__handleCloseDelegates, true);
+    this.removeEventListener('click', handleCloseDelegates, true);
   }
 
   show() {
     this.open = true;
 
     this.dispatchEvent(new Event('show'));
-  };
+  }
 
   close(type: 'close' | 'cancel' = 'close') {
     this.open = false;
 
     this.dispatchEvent(new Event(type));
-  };
+  }
 
   protected __cancel = this.close.bind(this, 'cancel');
 
-  protected __handleCloseDelegates(evt: Event) {
-    const target = evt.target as HTMLElement;
-
-    if (target.matches('[data-a11y-dialog-close]')) {
-      this.close();
-    }
-
-    if (target.matches('[data-a11y-dialog-cancel]')) {
-      this.__cancel();
-    }
-  };
 
   /**
    * Private event handler used when listening to some specific key presses
@@ -105,7 +110,7 @@ export class A11yDialog extends HTMLElement {
     if (event.key === 'Tab') {
       trapTabKey(this, event);
     }
-  };
+  }
 
   protected maintainFocus(event: FocusEvent) {
     if (
@@ -114,7 +119,7 @@ export class A11yDialog extends HTMLElement {
       )
     )
       moveFocusToDialog(this);
-  };
+  }
 
   attributeChangedCallback(
     name: string,


### PR DESCRIPTION
## Summary

1. Pulls some delegated event listeners out of the class definition, so they are not re-defined for every instance of the component.
2. Attaches all listeners directly to the host element and bunds/unbinds them in `connectedCallback`/`disconnectedCallback`.
3. Updates the demo a little